### PR TITLE
Update brew formula for iota v0.10.1-beta

### DIFF
--- a/Formula/iota.rb
+++ b/Formula/iota.rb
@@ -3,10 +3,10 @@ class Iota < Formula
     homepage "https://www.iota.org"
     license "Apache-2.0"
 
-    version "0.9.2-rc"
+    version "{{version}}"
     checksums = {
-        "macos-arm64" => "2c67e4794d413152b81e20caf9a7a4c52efdccd88f398ca728ab8fa20d6fd9ba",
-        "linux-x86_64" => "38569e53b2807a4ff2eaaf8a9c3c01df3a675b40d86ac3d7492c9fb051fe9b24"
+        "macos-arm64" => "{{macos-arm64-checksum}}",
+        "linux-x86_64" => "{{linux-x86_64-checksum}}"
     }
     arch = ""
 


### PR DESCRIPTION
## Description A new release has been published on https://github.com/iotaledger/iota: ### iota v0.10.1-beta From release: https://github.com/iotaledger/iota/actions/runs/{{run_id}}